### PR TITLE
去掉main.less里面对spriteIconMixin的强制引用

### DIFF
--- a/src/main.less
+++ b/src/main.less
@@ -1,5 +1,4 @@
 @import "mixin";
-@import "spriteIconMixin";
 
 @import "TextBox.less";
 @import "Button.less";
@@ -15,4 +14,3 @@
 @import "Tip.less";
 @import "TipLayer.less";
 @import "CommandMenu.less";
-// @import "Sidebar.less";


### PR DESCRIPTION
去掉main.less里面对spriteIconMixin的强制引用
